### PR TITLE
Add some info + remaining broken links

### DIFF
--- a/docs/practical/DataAnalysis.md
+++ b/docs/practical/DataAnalysis.md
@@ -16,7 +16,7 @@ Might there be a dataset or a tool out there that does what you need? Check out 
 ### General resources and instructions to getting started
 1. [Download and install Anaconda](https://www.anaconda.com/products/individual)
 2. [Download and install git](https://git-scm.com/downloads). See [here](https://missing.csail.mit.edu/2020/version-control/) for an excellent instroduction.
-3. [Download and install VSCode](https://code.visualstudio.com/), including the AutoPilot and Remote extensions (the latter for working on the ALICE cluster)
+3. [Download and install VSCode](https://code.visualstudio.com/), including the AutoPilot and [VSCode Remote Mode] (https://code.visualstudio.com/docs/remote/ssh) extensions (the latter for working on the ALICE cluster)
 4. [Continue](https://anne-urai.github.io/lab_wiki/IBLdata.html) to setup your environment for analyzing IBL data (and select `iblenv` as your interpreter in VSCode)
 
 ## Python and data analysis references

--- a/docs/practical/DataCollection.md
+++ b/docs/practical/DataCollection.md
@@ -60,4 +60,19 @@ a) Cyberduck
  * When logged in, the EduVPN window will pop up, it needs to be turned on (green light) to work
  * The J-drive will appear under "This PC"
  * Note: This only works for Windows users.
+
+ c) terminal mount on MacOS
+ This is an option for moe advanced terminal users, proceed with caution. _FOR THIS YOU NNEED TO ALLOW FILE SYSTEMS EXTENSIONS!_
+ * install MACfuse and ssfhs from https://macfuse.github.io
+ * create the folder you want to mount to, i.e. make the folder you want to mount to /data-sources/j-drive/<project-folder>
+ * open the terminal and paste  
+ ```
+ sshfs <your-login>>@sftpgw.leidenuniv.nl:/winshare/Public/Workgroups/FSW/<project-folder> <full-mount-path(above step)> -o defer_permissions,reconnect ServerAliveInterval=15
+  ```
+  _you will be prompted to type in your password_
+  
+  * If you loose connection you might have to unmount the drive manualy:
+  ```
+   umount <your-login>@sftpgw.leidenuniv.nl:/winshare/Public/Workgroups/FSW/<project-folder>
+  ```
  

--- a/docs/practical/DataCollection.md
+++ b/docs/practical/DataCollection.md
@@ -63,7 +63,7 @@ a) Cyberduck
 
  c) terminal mount on MacOS
  This is an option for moe advanced terminal users, proceed with caution. _FOR THIS YOU NNEED TO ALLOW FILE SYSTEMS EXTENSIONS!_
- * install MACfuse and ssfhs from https://macfuse.github.io
+ * install MACfuse and ssfhs from https://macfuse.github.io and follow instructions on how to setup
  * create the folder you want to mount to, i.e. make the folder you want to mount to /data-sources/j-drive/<project-folder>
  * open the terminal and paste  
  ```

--- a/docs/practical/DataCollection.md
+++ b/docs/practical/DataCollection.md
@@ -37,7 +37,7 @@ SOLO is the main source of support at the university. Here are their main channe
 - participant recruitment strategy (ask Anne for info on payments)
 
 ## Storing and loading internal data
-* Data from experiments run in the lab should be stored on the J-drive: `WORKGROUPS/FSW/PROJECT-NAME`. Anne will request access for you at the start of the project. The J-drive can be accessed from the lab computers: when you are logged in with your account, you should see the J-drive appear next to other network drives. 
+* Data from experiments run in the lab should be stored on the J-drive: `WORKGROUPS/FSW/PROJECT-NAME`. Anne will request access for you at the start of the project. The J-drive can be accessed from the lab computers: when you are logged in with your account, you should see the J-drive appear next to other network drives. ALICE setup needs to happen before j-drive (the password to ALICE is the password you need to mount jdrive).
 
 ## Accessing the J-drive on your own computer
 a) Cyberduck

--- a/docs/practical/Working time and meetings.md
+++ b/docs/practical/Working time and meetings.md
@@ -10,6 +10,8 @@ I am committed to creating a healthy work environment for all lab members. I enc
 
 I aim to schedule all meetings within regular work hours, and will refrain from sending, or answering, non-urgent emails/messages outside of work hours.
 
+The _Faculty of Social and Behavioural Sciences (FSW)_ building is open from 7AM until 8 PM (exept Tuesday until 10PM). It is closed on the weekends. 
+
 I expect all lab members to be in the office at least 3 days a week (often Mon/Tues/Thurs), during regular office hours (~10:00-17:00). If you are away or working remotely, please inform me and note this in the lab calendar. In general, I believe that some regular onsite presence is important to maintain the lab community. However, I am happy to support intermittent periods of fully-remote working when, for example, traveling/visiting family abroad or writing up a thesis/grant - please discuss with me, and make sure we document expectations (e.g. in a mentoring agreement).
 
 Discussing scientific progress is essential for the success of our projects. I expect all lab members to actively participate in our scheduled meetings: 

--- a/docs/practical/Working time and meetings.md
+++ b/docs/practical/Working time and meetings.md
@@ -18,7 +18,7 @@ Discussing scientific progress is essential for the success of our projects. I e
 
 #### Additional meetings
 - For climate psychology: Cameron Brick's lab meeting is often on Zoom, as well as the NYU climate psychology working group (sign up for their mailing lists, email Danielle Goldwert).
-- For social psychology: the [Social, Economic and Organisational Psychology unit is useful for some climate-related topics. Ask [Tycho](https://www.universiteitleiden.nl/en/staffmembers/tycho-van-tartwijk#tab-1) to be added.
+- For social psychology: the Social, Economic and Organisational Psychology unit is useful for some climate-related topics. Ask [Tycho](https://www.universiteitleiden.nl/en/staffmembers/tycho-van-tartwijk#tab-1) to be added.
 
 Every semester (2x/year), we also aim to have a writing week (often in Leiden's Academy Building) and a lab social/outing.
 


### PR DESCRIPTION
I have:
- added info on how to mount j-drive in terminal on Mac
-  added some small clarifications on the order of setting access to j-drive /ALICE
- small typos
- added missing links to extensions in VScode
- added info on opening hours of the building

Still missing but I didn't know how to fix: 
- in https://anne-urai.github.io/lab_wiki/practical/Working%20time%20and%20meetings.html  "On Thursday, the [[weekly CogPsy meeting](https://anne-urai.github.io/lab_wiki/Practical.html)](https://anne-urai.github.io/lab_wiki/Practical.html) and CO-squared joint lab meeting.” this link is 404 and unclear what should be here. 
- in https://anne-urai.github.io/lab_wiki/practical/DataAnalysis.html . Not clear what is AutoPilot for, i disabled all AI features, is this something the lab uses specifically?
- Creating account on Alice or SHARK requires knowing what your project is per https://leidenuniv.eu.qualtrics.com/jfe/form/SV_dhGhs7IqqkvYUmi not sure it needs to be changed but I was a bit confused at first
- (instructions on how to run group decision making )link is 404
- in https://anne-urai.github.io/lab_wiki/practical/Writing.html#revisions "See [this rebuttal](https://static-content.springer.com/esm/art%3A10.1038%2Fncomms14637/MediaObjects/41467_2017_BFncomms14637_MOESM2317_ESM.pdfhttps://static-content.springer.com/esm/art%3A10.1038%2Fncomms14637/MediaObjects/41467_2017_BFncomms14637_MOESM2317_ESM.pdf) to my first paper for a format to follow." link doesn't work